### PR TITLE
Disable running pipeline on apptainer

### DIFF
--- a/.github/workflows/download_pipeline.yml
+++ b/.github/workflows/download_pipeline.yml
@@ -12,14 +12,6 @@ on:
         required: true
         default: "dev"
   pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-    branches:
-      - main
-      - master
-  pull_request_target:
     branches:
       - main
       - master
@@ -69,11 +61,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/nf-core/tools.git@dev
+          pip install git+https://github.com/nf-core/tools.git
 
       - name: Cleanup apptainer cache before pull
         run: |
-          apptainer cache clean --all || true
+          apptainer cache clean --force || true
 
       - name: Download the pipeline
         run: |
@@ -99,36 +91,43 @@ jobs:
           echo "Initial container image count: $image_count"
           echo "IMAGE_COUNT_INITIAL=$image_count" >> "$GITHUB_OUTPUT"
 
-      - name: Run the downloaded pipeline (stub)
-        id: stub_run_pipeline
-        continue-on-error: true
-        env:
-          NXF_SINGULARITY_HOME_MOUNT: true
-        run: nextflow run ./${{needs.configure.outputs.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ needs.configure.outputs.REPO_BRANCH }}) -stub -profile test,singularity --outdir ./results
-      - name: Run the downloaded pipeline (stub run not supported)
-        id: run_pipeline
-        if: ${{ steps.stub_run_pipeline.outcome == 'failure' }}
-        env:
-          NXF_SINGULARITY_HOME_MOUNT: true
-        run: nextflow run ./${{ needs.configure.outputs.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ needs.configure.outputs.REPO_BRANCH }}) -profile test,singularity --outdir ./results
+      # - name: Run the downloaded pipeline (stub)
+      #   id: stub_run_pipeline
+      #   continue-on-error: true
+      #   env:
+      #     NXF_SINGULARITY_HOME_MOUNT: true
+      #   run: nextflow run ./${{needs.configure.outputs.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ needs.configure.outputs.REPO_BRANCH }}) -stub -profile test,singularity --outdir ./results
+      # - name: Run the downloaded pipeline (stub run not supported)
+      #   id: run_pipeline
+      #   if: ${{ steps.stub_run_pipeline.outcome == 'failure' }}
+      #   env:
+      #     NXF_SINGULARITY_HOME_MOUNT: true
+      #   run: nextflow run ./${{ needs.configure.outputs.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ needs.configure.outputs.REPO_BRANCH }}) -profile test,singularity --outdir ./results
 
-      - name: Count the downloaded number of container images
-        id: count_afterwards
-        run: |
-          image_count=$(ls -1 $NXF_SINGULARITY_CACHEDIR | wc -l | xargs)
-          echo "Post-pipeline run container image count: $image_count"
-          echo "IMAGE_COUNT_AFTER=$image_count" >> "$GITHUB_OUTPUT"
+      # - name: Count the downloaded number of container images
+      #   id: count_afterwards
+      #   run: |
+      #     image_count=$(ls -1 $NXF_SINGULARITY_CACHEDIR | wc -l | xargs)
+      #     echo "Post-pipeline run container image count: $image_count"
+      #     echo "IMAGE_COUNT_AFTER=$image_count" >> "$GITHUB_OUTPUT"
 
-      - name: Compare container image counts
-        run: |
-          if [ "${{ steps.count_initial.outputs.IMAGE_COUNT_INITIAL }}" -ne "${{ steps.count_afterwards.outputs.IMAGE_COUNT_AFTER }}" ]; then
-            initial_count=${{ steps.count_initial.outputs.IMAGE_COUNT_INITIAL }}
-            final_count=${{ steps.count_afterwards.outputs.IMAGE_COUNT_AFTER }}
-            difference=$((final_count - initial_count))
-            echo "$difference additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
-            tree $NXF_SINGULARITY_CACHEDIR > ./container_afterwards
-            diff ./container_initial ./container_afterwards
-            exit 1
-          else
-            echo "The pipeline can be downloaded successfully!"
-          fi
+      # - name: Compare container image counts
+      #   run: |
+      #     if [ "${{ steps.count_initial.outputs.IMAGE_COUNT_INITIAL }}" -ne "${{ steps.count_afterwards.outputs.IMAGE_COUNT_AFTER }}" ]; then
+      #       initial_count=${{ steps.count_initial.outputs.IMAGE_COUNT_INITIAL }}
+      #       final_count=${{ steps.count_afterwards.outputs.IMAGE_COUNT_AFTER }}
+      #       difference=$((final_count - initial_count))
+      #       echo "$difference additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
+      #       tree $NXF_SINGULARITY_CACHEDIR > ./container_afterwards
+      #       diff ./container_initial ./container_afterwards
+      #       exit 1
+      #     else
+      #       echo "The pipeline can be downloaded successfully!"
+      #     fi
+
+      # - name: Upload Nextflow logfile for debugging purposes
+      #   uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      #   with:
+      #     name: nextflow_logfile.txt
+      #     path: .nextflow.log*
+      #     include-hidden-files: true


### PR DESCRIPTION
For, now, running `apptainer` containers in the cluster does not work. I investigated how to implement support for it, but it could require long re-configuration of the cluster.

So, for the moment, I'd rather disable the **stub run** at the end of the **download pipeline** github workflow. The check still has some validity, it just doesn't validate the containers are loaded at runtime by the pipeline.