### PR TITLE
FIX: Stats files referenced before creation or modification

### DIFF
--- a/workflows/sf-tractomics.nf
+++ b/workflows/sf-tractomics.nf
@@ -467,12 +467,12 @@ def collectStatsFiles(ch_stats_files, name, storeDir) {
 
     def output_file_path = "${storeDir}/${name}"
 
-    ch_stats_files = ch_stats_files
-        .map{ _meta, stats_file ->
+    return ch_stats_files
+        .map { _meta, stats_file ->
             return stats_file
         }
         .collect()
-        .subscribe { stats_files ->
+        .map { stats_files ->
             def header_written = false
             def all_columns = new LinkedHashSet()
 
@@ -518,9 +518,9 @@ def collectStatsFiles(ch_stats_files, name, storeDir) {
 
             // Close the file writer
             file_writer.close()
-        }
 
-    return channel.fromPath(output_file_path)
+            return output_file
+        }
 }
 
 /*


### PR DESCRIPTION
Before, the results weren't even collected (thus not creating the file) and the function returned channel.fromPath("...") before the file was even created. This caused the harmonization to try to run on either:
- A non-existent file => crashes
- An outdated version of the file (if the pipeline run was resumed) => wrong results or crashes

This fix is aimed to return the channel resulting from the file collection directly, this way it doesn't cause issues with race conditions.