### PR TITLE
FIX: publish harmonization models

### DIFF
--- a/conf/modules/harmonization.config
+++ b/conf/modules/harmonization.config
@@ -13,6 +13,15 @@
 includeConfig '../../subworkflows/nf-neuro/harmonization/nextflow.config'
 
 process {
+    withName: ".*:HARMONIZATION:CLINICALCOMBAT" {
+        publishDir = [
+            [
+                path: "${params.outdir}/harmonization_models/",
+                mode: params.publish_dir_mode,
+                pattern: "*.model.csv"
+            ]
+        ]
+    }
     withName: ".*:HARMONIZATION:COMBAT2STATS" {
         publishDir = [
             [


### PR DESCRIPTION
Forgot to publish the harmonization models. These essentially represent the harmonization function that was fitted to the data. The published files are required to apply the fitted harmonization to new subjects.

Please notice the new directory name under the `params.outdir` directory.